### PR TITLE
Ds3231 init check

### DIFF
--- a/firmware/src/fw/main.c
+++ b/firmware/src/fw/main.c
@@ -761,7 +761,12 @@ int main() {
     ds3231_init(&rtc, I2C_PIO, I2C_SM, pio_i2c_write_blocking, pio_i2c_read_blocking);
     sleep_ms(1); // without this, garbage values are read from the RTC
     LOG("DS3231", "Reading datetime\n");
-    ds3231_get_datetime(&rtc, &tm_now);
+    if (!ds3231_get_datetime(&rtc, &tm_now)) {
+        LOG("DS3231", "RTC not connected\n");
+        setup_display(&disp);
+        display_message(&disp, "RTC ERR");
+        while (true) { tight_loop_contents(); }
+    }
     LOG("DS3231", "Time: %04d-%02d-%02d %02d:%02d:%02d\n", tm_now.tm_year + 1900, tm_now.tm_mon + 1, tm_now.tm_mday,
         tm_now.tm_hour, tm_now.tm_min, tm_now.tm_sec);
 

--- a/firmware/src/rtc/ds3231.h
+++ b/firmware/src/rtc/ds3231.h
@@ -1,6 +1,7 @@
 #ifndef _DS3231_H
 #define _DS3231_H
 
+#include <stdbool.h>
 #include <time.h>
 #include "../pio_i2c/pio_i2c.h"
 
@@ -18,7 +19,7 @@ struct ds3231 {
 void ds3231_init(struct ds3231 *d, PIO pio, uint sm, int (*i2c_write)(PIO, uint, uint8_t, const uint8_t *, uint),
                  int (*i2c_read)(PIO, uint, uint8_t, uint8_t *, uint));
 
-void ds3231_get_datetime(struct ds3231 *d, struct tm *tm);
+bool ds3231_get_datetime(struct ds3231 *d, struct tm *tm);
 
 void ds3231_set_datetime(struct ds3231 *d, const struct tm *tm);
 


### PR DESCRIPTION
This PR, branched from pico2, adds a verification if the DS3231 is responding and errors otherwise.
The current behaviour is to proceed with init, using the empty tm structure.