### PR TITLE
[DRAFT] Show a speed graph on the dashboard from track data

### DIFF
--- a/dashboard/app/api/session/routes.py
+++ b/dashboard/app/api/session/routes.py
@@ -315,7 +315,12 @@ def session_html(session_id: uuid.UUID):
     session_html = db.session.execute(db.select(SessionHtml).filter_by(
         session_id=session.id)).scalar_one_or_none()
     if not session_html:
-        return jsonify(), status.NOT_FOUND
+        # Regenerate cache on demand (not just return 404)
+        create_cache(session.id, 5, 200)
+        session_html = db.session.execute(db.select(SessionHtml).filter_by(
+            session_id=session.id)).scalar_one_or_none()
+        if not session_html:
+            return jsonify(), status.NOT_FOUND
 
     # If cached Bokeh document was generated with a previous version of Bokeh,
     # we need to delete and regenerate the cache.
@@ -331,6 +336,7 @@ def session_html(session_id: uuid.UUID):
     components_script = Markup(session_html.script.replace(
         '<script type="text/javascript">', '').replace('</script>', ''))
     components_divs = [Markup(d) if d else None for d in session_html.divs]
+    has_speed = session_html.speed is not None and session_html.speed != ""
 
     track = Track.get(session.track)
 
@@ -347,8 +353,8 @@ def session_html(session_id: uuid.UUID):
     elapsed_time = record_num / t.SampleRate
     start_time = session.timestamp
     end_time = start_time + elapsed_time
-    full_track, session_track = track_data(track.track if track else None,
-                                           start_time, end_time)
+    full_track, session_track, _ = track_data(track.track if track else None,
+                                              start_time, end_time)
 
     response = jsonify(
         id=session.id,
@@ -369,6 +375,7 @@ def session_html(session_id: uuid.UUID):
         suspension_count=suspension_count,
         full_track=full_track,
         session_track=session_track,
+        has_speed=has_speed,
         script=components_script,
         divs=components_divs,
         full_access=full_access,
@@ -394,7 +401,7 @@ def upload_gpx(id: uuid.UUID):
 
     track_dict = gpx_to_dict(request.data)
     ts, tf = track_dict['time'][0], track_dict['time'][-1]
-    full_track, session_track = track_data(track_dict, start_time, end_time)
+    full_track, session_track, _ = track_data(track_dict, start_time, end_time)
     if session_track is None:
         return jsonify(msg="Track is not applicable!"), status.BAD_REQUEST
 
@@ -419,6 +426,12 @@ def upload_gpx(id: uuid.UUID):
         .values(track=new_track.id)
     )
     db.session.execute(stmt_update)
+    db.session.commit()
+
+    # Invalidate cached HTML for affected sessions
+    db.session.execute(
+        db.delete(SessionHtml).filter(SessionHtml.session_id.in_(stmt_select))
+    )
     db.session.commit()
 
     data = dict(full_track=full_track, session_track=session_track)

--- a/dashboard/app/models/session_html.py
+++ b/dashboard/app/models/session_html.py
@@ -12,6 +12,7 @@ class SessionHtml(db.Model):
     script: str = db.Column(db.String, nullable=False)
     travel: str = db.Column(db.String, nullable=False)
     velocity: str = db.Column(db.String, nullable=False)
+    speed: str = db.Column(db.String)  # nullable for sessions without GPS
     map: str = db.Column(db.String, nullable=False)
     lr: str = db.Column(db.String, nullable=False)
     sw: str = db.Column(db.String, nullable=False)

--- a/dashboard/app/models/track.py
+++ b/dashboard/app/models/track.py
@@ -21,6 +21,9 @@ class Track(db.Model, Synchronizable):
                 track['ele'],
                 track['time']
             ]
+            # Speed is optional for backwards compatibility with existing tracks
+            if 'speed' in track:
+                data.append(track['speed'])
         except BaseException:
             return False
         return len(set(map(len, data))) == 1 and len(data[0]) >= 1

--- a/dashboard/app/static/layout-double.css
+++ b/dashboard/app/static/layout-double.css
@@ -34,14 +34,19 @@
     grid-template-columns: 100%;
     grid-auto-rows: max-content;
   }
-  
+
   .tabs          { grid-column: 1; grid-row: 1; }
   .video-map     { grid-column: 1; grid-row: 2; }
   .travel        { grid-column: 1; grid-row: 3; }
   .velocity      { grid-column: 1; grid-row: 4; }
+  .speed         { grid-column: 1; grid-row: 5; }
   .lr            { grid-column: 1; grid-row: 6; }
   .sw            { grid-column: 1; grid-row: 7; }
   .description   { grid-column: 1; grid-row: 8; }
+
+  .has-speed .lr          { grid-row: 7; }
+  .has-speed .sw          { grid-row: 8; }
+  .has-speed .description { grid-row: 9; }
 
   .tabs.novidmap { grid-column: 1; grid-row: 1 / 3; }
   
@@ -83,11 +88,18 @@
 
   .travel        { grid-column: 1 / 5; grid-row: 1; }
   .velocity      { grid-column: 1 / 5; grid-row: 2; }
+  .speed         { grid-column: 1 / 5; grid-row: 3; }
   .video-map     { grid-column: 1 / 5; grid-row: 3; }
   .tabs          { grid-column: 1 / 5; grid-row: 4; }
   .lr            { grid-column: 1 / 3; grid-row: 5; }
   .sw            { grid-column: 3 / 5; grid-row: 5; }
   .description   { grid-column: 1 / 5; grid-row: 6; }
+
+  .has-speed .video-map   { grid-row: 4; }
+  .has-speed .tabs        { grid-row: 5; }
+  .has-speed .lr          { grid-row: 6; }
+  .has-speed .sw          { grid-row: 6; }
+  .has-speed .description { grid-row: 7; }
 
   .video-loaded  { width: 50%; }
   .tabs.novidmap { grid-column: 1 / 5; grid-row: 3; }
@@ -100,14 +112,21 @@
     grid-template-columns: repeat(8, 1fr);
     grid-auto-rows: max-content;
   }
-    
+
   .travel            { grid-column: 1 / 7; grid-row: 1;     }
   .velocity          { grid-column: 1 / 7; grid-row: 2;     }
+  .speed             { grid-column: 1 / 7; grid-row: 3;     }
   .video-map         { grid-column: 7 / 9; grid-row: 1 / 3; }
   .tabs              { grid-column: 1 / 7; grid-row: 3 / 5; }
   .lr                { grid-column:     7; grid-row: 3;     }
   .sw                { grid-column:     8; grid-row: 3;     }
   .description       { grid-column: 7 / 9; grid-row: 4;     }
+
+  .has-speed .video-map   { grid-row: 1 / 4; }
+  .has-speed .tabs        { grid-row: 4 / 6; }
+  .has-speed .lr          { grid-row: 4;     }
+  .has-speed .sw          { grid-row: 4;     }
+  .has-speed .description { grid-row: 5;     }
 
   .travel.novidmap   { grid-column: 1 / 9; grid-row: 1;     }
   .velocity.novidmap { grid-column: 1 / 9; grid-row: 2;     }

--- a/dashboard/app/static/layout-single.css
+++ b/dashboard/app/static/layout-single.css
@@ -24,14 +24,19 @@
     grid-template-columns: 100%;
     grid-auto-rows: max-content;
   }
-  
+
   .tabs          { grid-column: 1; grid-row: 1; }
   .video-map     { grid-column: 1; grid-row: 2; }
   .travel        { grid-column: 1; grid-row: 3; }
   .velocity      { grid-column: 1; grid-row: 4; }
+  .speed         { grid-column: 1; grid-row: 5; }
   .lr            { grid-column: 1; grid-row: 6; }
   .sw            { grid-column: 1; grid-row: 7; }
   .description   { grid-column: 1; grid-row: 8; }
+
+  .has-speed .lr          { grid-row: 7; }
+  .has-speed .sw          { grid-row: 8; }
+  .has-speed .description { grid-row: 9; }
 
   .video-loaded  { width: 50%; }
   .tabs.novidmap { grid-column: 1; grid-row: 1 / 3; }
@@ -44,14 +49,21 @@
     grid-template-columns: repeat(8, 1fr);
     grid-auto-rows: max-content;
   }
-    
+
   .travel            { grid-column: 1 / 7; grid-row: 1;     }
   .velocity          { grid-column: 1 / 7; grid-row: 2;     }
+  .speed             { grid-column: 1 / 7; grid-row: 3;     }
   .video-map         { grid-column: 7 / 9; grid-row: 1 / 3; }
   .tabs              { grid-column: 1 / 7; grid-row: 3 / 5; }
   .lr                { grid-column:     7; grid-row:     3; }
   .sw                { grid-column:     8; grid-row:     3; }
   .description       { grid-column: 7 / 9; grid-row:     4; }
+
+  .has-speed .video-map   { grid-row: 1 / 4; }
+  .has-speed .tabs        { grid-row: 4 / 6; }
+  .has-speed .lr          { grid-row: 4;     }
+  .has-speed .sw          { grid-row: 4;     }
+  .has-speed .description { grid-row: 5;     }
 
   .travel.novidmap   { grid-column: 1 / 9; grid-row: 1;     }
   .velocity.novidmap { grid-column: 1 / 9; grid-row: 2;     }

--- a/dashboard/app/telemetry/map.py
+++ b/dashboard/app/telemetry/map.py
@@ -15,6 +15,9 @@ from bokeh.plotting import figure
 from scipy.interpolate import pchip_interpolate
 
 
+EARTH_RADIUS_KM = 6371.0
+
+
 def _geographic_to_mercator(y_lat: float, x_lon: float) -> (float, float):
     if abs(x_lon) > 180 or abs(y_lat) >= 90:
         return None
@@ -24,6 +27,25 @@ def _geographic_to_mercator(y_lat: float, x_lon: float) -> (float, float):
     a = y_lat * 0.017453292519943295
     y_m = 3189068.5 * math.log((1.0 + math.sin(a)) / (1.0 - math.sin(a)))
     return y_m, x_m
+
+
+def _haversine_distance_km(lat1: float, lon1: float,
+                           lat2: float, lon2: float) -> float:
+    """Calculate distance between two GPS points in kilometers.
+
+    Uses Haversine formula. Input coordinates in degrees (WGS84).
+    """
+    lat1_rad = math.radians(lat1)
+    lat2_rad = math.radians(lat2)
+    delta_lat = math.radians(lat2 - lat1)
+    delta_lon = math.radians(lon2 - lon1)
+
+    a = (math.sin(delta_lat / 2) ** 2 +
+         math.cos(lat1_rad) * math.cos(lat2_rad) *
+         math.sin(delta_lon / 2) ** 2)
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+    return EARTH_RADIUS_KM * c
 
 
 def _session_track(start: int, end: int, t: np.array, track: dict) -> (
@@ -46,32 +68,92 @@ def _session_track(start: int, end: int, t: np.array, track: dict) -> (
 
     return dict(lon=list(y[0, :]), lat=list(y[1, :]))
 
+def _session_speed(start: int, end: int, t: np.array,
+                   speed: list[float]) -> list[float]:
+    """Get speed data interpolated to session time range at 10Hz.
+
+    Same interpolation as _session_track for alignment.
+    Returns None if no speed data or time range invalid.
+    """
+    if not speed:
+        return None
+
+    session_indices = np.where(np.logical_and(t >= start, t <= end))
+    if len(session_indices[0]) == 0:
+        return None
+
+    start_idx = session_indices[0][0]
+    end_idx = session_indices[0][-1] + 1
+
+    session_speed_raw = np.array(speed[start_idx:end_idx])
+    session_time = np.array(t[start_idx:end_idx]) - start
+    session_time[0] = 0
+
+    # Interpolate to 10Hz (0.1s intervals) - same as _session_track
+    x = np.arange(0, session_time[-1], 0.1)
+    speed_interp = pchip_interpolate(session_time, session_speed_raw, x)
+
+    return list(speed_interp)
+
 
 def gpx_to_dict(gpx_data: str) -> dict[str, Any]:
-    gpx_dict = dict(lat=[], lon=[], ele=[], time=[])
+    gpx_dict = dict(lat=[], lon=[], ele=[], time=[], speed=[])
+
+    prev_lat = None
+    prev_lon = None
+    prev_time = None
+
     gpx_file = io.BytesIO(gpx_data)
     gpx = gpxpy.parse(gpx_file)
+
     for track in gpx.tracks:
         for segment in track.segments:
             for point in segment.points:
-                lat, lon = _geographic_to_mercator(point.latitude,
-                                                   point.longitude)
-                gpx_dict['lat'].append(lat)
-                gpx_dict['lon'].append(lon)
+                lat = point.latitude
+                lon = point.longitude
+                time = point.time.timestamp()
+
+                # Calculate speed from previous point (raw WGS84)
+                if prev_lat is not None:
+                    dist_km = _haversine_distance_km(prev_lat, prev_lon, lat, lon)
+                    time_delta_hours = (time - prev_time) / 3600.0
+                    speed_kmh = dist_km / time_delta_hours if time_delta_hours > 0 else 0.0
+
+                    # First point gets same speed as second
+                    if len(gpx_dict['speed']) == 1:
+                        gpx_dict['speed'][0] = speed_kmh
+
+                    gpx_dict['speed'].append(speed_kmh)
+                else:
+                    # First point - placeholder, updated when we have second point
+                    gpx_dict['speed'].append(0.0)
+
+                # Convert to Mercator and store
+                merc_lat, merc_lon = _geographic_to_mercator(lat, lon)
+                gpx_dict['lat'].append(merc_lat)
+                gpx_dict['lon'].append(merc_lon)
+                gpx_dict['time'].append(time)
                 gpx_dict['ele'].append(point.elevation)
-                gpx_dict['time'].append(point.time.timestamp())
+
+                prev_lat = lat
+                prev_lon = lon
+                prev_time = time
+
     return gpx_dict
 
-
 def track_data(track: str, start_timestamp: int, end_timestamp: int) -> (
-               dict[str, Any], dict[str, list[float]]):
+               dict[str, Any], dict[str, list[float]], list[float]):
+    """Returns (full_track, session_track, session_speed_data)"""
     if not track:
-        return None, None
+        return None, None, None
 
     if type(track) is str:
         full_track = json.loads(track)
     else:
-        full_track = dict(track)  # Copy, so that we leage the original intact.
+        full_track = dict(track)  # Copy, so that we leave the original intact.
+
+    # Extract speed before removing from full_track
+    speed_data = full_track.pop('speed', None)
 
     # We don't yet use elevation data, so currently there is no need to include
     # it in the datasource. It is just saved to the database for future use.
@@ -85,7 +167,15 @@ def track_data(track: str, start_timestamp: int, end_timestamp: int) -> (
                                    timestamps,
                                    full_track)
 
-    return full_track, session_track
+    # Get interpolated session speed
+    sess_speed = None
+    if speed_data and session_track:
+        sess_speed = _session_speed(start_timestamp,
+                                    end_timestamp,
+                                    timestamps,
+                                    speed_data)
+
+    return full_track, session_track, sess_speed
 
 
 def map_figure() -> (figure, CustomJS):

--- a/dashboard/app/telemetry/map.py
+++ b/dashboard/app/telemetry/map.py
@@ -212,7 +212,7 @@ def map_figure() -> (figure, CustomJS):
     p.add_glyph(cs)
     p.add_glyph(ce)
 
-    pos_marker = Circle(name="pos_marker", x=0, y=0, radius=13,
+    pos_marker = Circle(name="pos_marker", x=0, y=0, radius=10, radius_units='screen',
                         line_color='black', fill_color='gray')
     p.add_glyph(pos_marker)
 

--- a/dashboard/app/telemetry/session_html.py
+++ b/dashboard/app/telemetry/session_html.py
@@ -111,6 +111,12 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
     p_velocity.x_range.js_link('start', p_travel.x_range, 'start')
     p_velocity.x_range.js_link('end', p_travel.x_range, 'end')
 
+    # Link crosshair overlays between travel and velocity
+    travel_overlay = p_travel.toolbar.active_inspect.overlay
+    velocity_overlay = p_velocity.toolbar.active_inspect.overlay
+    travel_overlay.js_link('location', velocity_overlay, 'location')
+    velocity_overlay.js_link('location', travel_overlay, 'location')
+
     # Create speed figure if speed data available
     if session_speed_data:
         p_speed = speed_figure(session_speed_data)
@@ -126,6 +132,13 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
         p_speed.x_range.js_link('end', p_velocity.x_range, 'end')
         p_velocity.x_range.js_link('start', p_speed.x_range, 'start')
         p_velocity.x_range.js_link('end', p_speed.x_range, 'end')
+
+        # Link speed crosshair overlay with travel and velocity
+        speed_overlay = p_speed.toolbar.active_inspect.overlay
+        travel_overlay.js_link('location', speed_overlay, 'location')
+        speed_overlay.js_link('location', travel_overlay, 'location')
+        velocity_overlay.js_link('location', speed_overlay, 'location')
+        speed_overlay.js_link('location', velocity_overlay, 'location')
 
     '''
     Leverage-related graphs. These are input data, not something measured.

--- a/dashboard/app/telemetry/session_html.py
+++ b/dashboard/app/telemetry/session_html.py
@@ -195,6 +195,81 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
     on_seek.code = on_seek_code
     p_travel.toolbar.active_inspect.overlay.js_on_change('location', on_seek)
 
+    ds_session = p_map.select_one(dict(name='ds_session'))
+    if ds_session:
+        zoom_map_code = '''
+            const start_t = cb_obj.start;
+            const end_t = cb_obj.end;
+
+            const lat = source.data['lat'];
+            const lon = source.data['lon'];
+
+            // 10Hz data
+            let start_idx = Math.floor(start_t * 10);
+            let end_idx = Math.ceil(end_t * 10);
+
+            if (start_idx < 0) start_idx = 0;
+            if (end_idx > lon.length) end_idx = lon.length;
+
+            if (start_idx >= end_idx) return;
+
+            let min_x = Infinity, max_x = -Infinity;
+            let min_y = Infinity, max_y = -Infinity;
+
+            for (let i = start_idx; i < end_idx; i++) {
+                if (lon[i] < min_x) min_x = lon[i];
+                if (lon[i] > max_x) max_x = lon[i];
+                if (lat[i] < min_y) min_y = lat[i];
+                if (lat[i] > max_y) max_y = lat[i];
+            }
+
+            let data_w = max_x - min_x;
+            let data_h = max_y - min_y;
+            const center_x = (min_x + max_x) / 2;
+            const center_y = (min_y + max_y) / 2;
+
+            // Add 5% padding
+            data_w *= 1.05;
+            data_h *= 1.05;
+
+            // Ensure a minimum extent to avoid extreme zoom-in for very short segments
+            const MIN_EXTENT = 1000;
+            if (data_w < MIN_EXTENT) data_w = MIN_EXTENT;
+            if (data_h < MIN_EXTENT) data_h = MIN_EXTENT;
+
+            // Get plot aspect ratio
+            let aspect = 1.0;
+            if (plot.inner_height > 0) {
+                aspect = plot.inner_width / plot.inner_height;
+            }
+
+            let final_w, final_h;
+            if (data_w / data_h > aspect) {
+                // Width constrained
+                final_w = data_w;
+                final_h = data_w / aspect;
+            } else {
+                // Height constrained
+                final_h = data_h;
+                final_w = final_h * aspect;
+            }
+
+            // Set ranges to form a bounding box centered around the visible track
+            map_x.start = center_x - final_w / 2;
+            map_x.end = center_x + final_w / 2;
+            map_y.start = center_y - final_h / 2;
+            map_y.end = center_y + final_h / 2;
+        '''
+        callback = CustomJS(
+            args=dict(source=ds_session,
+                      map_x=p_map.x_range,
+                      map_y=p_map.y_range,
+                      plot=p_map),
+            code=zoom_map_code
+        )
+        p_travel.x_range.js_on_change('start', callback)
+        p_travel.x_range.js_on_change('end', callback)
+
     '''
     Construct the layout.
     '''

--- a/dashboard/app/telemetry/session_html.py
+++ b/dashboard/app/telemetry/session_html.py
@@ -198,75 +198,19 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
     ds_session = p_map.select_one(dict(name='ds_session'))
     if ds_session:
         zoom_map_code = '''
-            const start_t = cb_obj.start;
-            const end_t = cb_obj.end;
-
-            const lat = source.data['lat'];
             const lon = source.data['lon'];
+            const lat = source.data['lat'];
 
-            // 10Hz data
-            let start_idx = Math.floor(start_t * 10);
-            let end_idx = Math.ceil(end_t * 10);
+            // 10Hz data - convert time range to indices
+            let start_idx = Math.floor(cb_obj.start * 10);
+            let end_idx = Math.ceil(cb_obj.end * 10);
 
             if (start_idx < 0) start_idx = 0;
             if (end_idx > lon.length) end_idx = lon.length;
 
-            if (start_idx >= end_idx) return;
-
-            let min_x = Infinity, max_x = -Infinity;
-            let min_y = Infinity, max_y = -Infinity;
-
-            for (let i = start_idx; i < end_idx; i++) {
-                if (lon[i] < min_x) min_x = lon[i];
-                if (lon[i] > max_x) max_x = lon[i];
-                if (lat[i] < min_y) min_y = lat[i];
-                if (lat[i] > max_y) max_y = lat[i];
-            }
-
-            let data_w = max_x - min_x;
-            let data_h = max_y - min_y;
-            const center_x = (min_x + max_x) / 2;
-            const center_y = (min_y + max_y) / 2;
-
-            // Add padding
-            data_w *= 1.1;
-            data_h *= 1.05;
-
-            // Ensure a minimum extent to avoid extreme zoom-in for very short segments
-            const MIN_EXTENT = 100;
-            if (data_w < MIN_EXTENT) data_w = MIN_EXTENT;
-            if (data_h < MIN_EXTENT) data_h = MIN_EXTENT;
-
-            // Get plot aspect ratio
-            let aspect = 1.0;
-            if (plot.inner_height > 0) {
-                aspect = plot.inner_width / plot.inner_height;
-            }
-
-            let final_w, final_h;
-            if (data_w / data_h > aspect) {
-                // Width constrained
-                final_w = data_w;
-                final_h = data_w / aspect;
-            } else {
-                // Height constrained
-                final_h = data_h;
-                final_w = final_h * aspect;
-            }
-
-            // Set ranges to form a bounding box centered around the visible track
-            map_x.start = center_x - final_w / 2;
-            map_x.end = center_x + final_w / 2;
-            map_y.start = center_y - final_h / 2;
-            map_y.end = center_y + final_h / 2;
+            SST.fitMapToTrack(lon, lat, start_idx, end_idx);
         '''
-        callback = CustomJS(
-            args=dict(source=ds_session,
-                      map_x=p_map.x_range,
-                      map_y=p_map.y_range,
-                      plot=p_map),
-            code=zoom_map_code
-        )
+        callback = CustomJS(args=dict(source=ds_session), code=zoom_map_code)
         p_travel.x_range.js_on_change('start', callback)
         p_travel.x_range.js_on_change('end', callback)
 

--- a/dashboard/app/telemetry/session_html.py
+++ b/dashboard/app/telemetry/session_html.py
@@ -13,10 +13,12 @@ from bokeh.themes import built_in_themes, DARK_MINIMAL
 from app.extensions import db
 from app.models.session import Session
 from app.models.session_html import SessionHtml
+from app.models.track import Track
 from app.telemetry.balance import balance_figure
 from app.telemetry.fft import fft_figure
 from app.telemetry.leverage import leverage_ratio_figure, shock_wheel_figure
-from app.telemetry.map import map_figure
+from app.telemetry.map import map_figure, track_data
+from app.telemetry.speed import speed_figure
 from app.telemetry.psst import Telemetry, dataclass_from_dict
 from app.telemetry.travel import travel_figure, travel_histogram_figure
 from app.telemetry.velocity import velocity_figure
@@ -35,8 +37,22 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
 
     d = msgpack.unpackb(session.data)
     telemetry = dataclass_from_dict(Telemetry, d)
-
     tick = 1.0 / telemetry.SampleRate  # time step length in seconds
+
+    # Load track data including speed
+    p_speed = None
+    session_speed_data = None
+    if session.track:
+        track = Track.get(session.track)
+        if track:
+            record_num = len(telemetry.Front.Travel if telemetry.Front.Present
+                            else telemetry.Rear.Travel)
+            elapsed_time = record_num / telemetry.SampleRate
+            start_time = session.timestamp
+            end_time = start_time + elapsed_time
+
+            _, _, session_speed_data = track_data(
+                track.track, start_time, end_time)
 
     if telemetry.Front.Present:
         p_front_travel_hist = travel_histogram_figure(
@@ -94,6 +110,22 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
     p_travel.x_range.js_link('end', p_velocity.x_range, 'end')
     p_velocity.x_range.js_link('start', p_travel.x_range, 'start')
     p_velocity.x_range.js_link('end', p_travel.x_range, 'end')
+
+    # Create speed figure if speed data available
+    if session_speed_data:
+        p_speed = speed_figure(session_speed_data)
+
+        # Link speed x_range with travel (bidirectional)
+        p_speed.x_range.js_link('start', p_travel.x_range, 'start')
+        p_speed.x_range.js_link('end', p_travel.x_range, 'end')
+        p_travel.x_range.js_link('start', p_speed.x_range, 'start')
+        p_travel.x_range.js_link('end', p_speed.x_range, 'end')
+
+        # Link speed x_range with velocity (bidirectional)
+        p_speed.x_range.js_link('start', p_velocity.x_range, 'start')
+        p_speed.x_range.js_link('end', p_velocity.x_range, 'end')
+        p_velocity.x_range.js_link('start', p_speed.x_range, 'start')
+        p_velocity.x_range.js_link('end', p_speed.x_range, 'end')
 
     '''
     Leverage-related graphs. These are input data, not something measured.
@@ -164,10 +196,11 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
 
     document.add_root(p_travel)
     document.add_root(p_velocity)
+    if p_speed:
+        document.add_root(p_speed)
     document.add_root(p_map)
     document.add_root(p_lr)
     document.add_root(p_sw)
-    columns = ['session_id', 'script', 'travel', 'velocity', 'map', 'lr', 'sw']
 
     if telemetry.Front.Present:
         prefix = 'front_' if suspension_count == 2 else ''
@@ -183,7 +216,6 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
         document.add_root(p_front_travel_hist)
         document.add_root(p_front_fft)
         document.add_root(p_front_velocity)
-        columns.extend(['f_thist', 'f_fft', 'f_vhist'])
     if telemetry.Rear.Present:
         prefix = 'rear_' if suspension_count == 2 else ''
         p_rear_travel_hist.name = f'{prefix}travel_hist'
@@ -198,11 +230,9 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
         document.add_root(p_rear_travel_hist)
         document.add_root(p_rear_fft)
         document.add_root(p_rear_velocity)
-        columns.extend(['r_thist', 'r_fft', 'r_vhist'])
     if suspension_count == 2:
         document.add_root(p_balance_compression)
         document.add_root(p_balance_rebound)
-        columns.extend(['cbalance', 'rbalance'])
 
     # Some Bokeh models (like the map) need to be dynamically initialized based
     # on values in a particular Flask session.
@@ -210,7 +240,40 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
         args=dict(), code='SST.init_models();'))
 
     script, divs = components(document.roots, theme=dark_minimal_theme)
-    components_data = dict(zip(columns, [session_id, script] + list(divs)))
+
+    # Map root names to div HTML strings
+    div_by_name = {root.name: div for root, div in zip(document.roots, divs)}
+
+    # Build components_data with explicit column mapping
+    # Speed will be None if p_speed was not added to roots
+    components_data = {
+        'session_id': session_id,
+        'script': script,
+        'travel': div_by_name.get('travel'),
+        'velocity': div_by_name.get('velocity'),
+        'speed': div_by_name.get('speed'),
+        'map': div_by_name.get('map'),
+        'lr': div_by_name.get('lr'),
+        'sw': div_by_name.get('sw'),
+    }
+
+    # Add conditional histogram columns based on suspension configuration
+    if telemetry.Front.Present:
+        hist_prefix = 'front_' if suspension_count == 2 else ''
+        components_data['f_thist'] = div_by_name.get(f'{hist_prefix}travel_hist')
+        components_data['f_fft'] = div_by_name.get(f'{hist_prefix}fft')
+        components_data['f_vhist'] = div_by_name.get(f'{hist_prefix}velocity_hist')
+
+    if telemetry.Rear.Present:
+        hist_prefix = 'rear_' if suspension_count == 2 else ''
+        components_data['r_thist'] = div_by_name.get(f'{hist_prefix}travel_hist')
+        components_data['r_fft'] = div_by_name.get(f'{hist_prefix}fft')
+        components_data['r_vhist'] = div_by_name.get(f'{hist_prefix}velocity_hist')
+
+    if suspension_count == 2:
+        components_data['cbalance'] = div_by_name.get('balance_compression')
+        components_data['rbalance'] = div_by_name.get('balance_rebound')
+
     session_html = dataclass_from_dict(SessionHtml, components_data)
 
     db.session.add(session_html)

--- a/dashboard/app/telemetry/session_html.py
+++ b/dashboard/app/telemetry/session_html.py
@@ -228,12 +228,12 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
             const center_x = (min_x + max_x) / 2;
             const center_y = (min_y + max_y) / 2;
 
-            // Add 5% padding
-            data_w *= 1.05;
+            // Add padding
+            data_w *= 1.1;
             data_h *= 1.05;
 
             // Ensure a minimum extent to avoid extreme zoom-in for very short segments
-            const MIN_EXTENT = 1000;
+            const MIN_EXTENT = 100;
             if (data_w < MIN_EXTENT) data_w = MIN_EXTENT;
             if (data_h < MIN_EXTENT) data_h = MIN_EXTENT;
 

--- a/dashboard/app/telemetry/speed.py
+++ b/dashboard/app/telemetry/speed.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+from bokeh.models import ColumnDataSource
+from bokeh.models.ranges import Range1d
+from bokeh.models.tools import WheelZoomTool
+from bokeh.palettes import Spectral11
+from bokeh.plotting import figure
+
+
+def speed_figure(speed_data: list[float], sample_rate: float = 10.0) -> figure:
+    """Create GPS speed figure.
+
+    Args:
+        speed_data: Speed values in km/h at 10Hz (0.1s intervals)
+        sample_rate: Samples per second (default 10Hz from GPS interpolation)
+
+    Returns:
+        Bokeh figure with speed line plot
+    """
+    length = len(speed_data)
+    time = np.around(np.arange(0, length) / sample_rate, 4)
+    speed = np.around(speed_data, 2)
+
+    source = ColumnDataSource(data=dict(t=time, s=speed))
+
+    p = figure(
+        name='speed',
+        title="GPS Speed",
+        height=275,
+        min_border_left=50,
+        min_border_right=50,
+        sizing_mode="stretch_width",
+        toolbar_location='above',
+        tools='xpan,reset,hover',
+        active_inspect=None,
+        active_drag='xpan',
+        tooltips=[("elapsed time", "@t s"),
+                  ("speed", "@s km/h")],
+        x_axis_label="Elapsed time (s)",
+        y_axis_label="Speed (km/h)",
+        output_backend='webgl')
+
+    p.x_range = Range1d(0, time[-1] if len(time) > 0 else 1, bounds='auto')
+
+    line = p.line(
+        't', 's',
+        legend_label="GPS Speed",
+        line_width=2,
+        color=Spectral11[4],  # Different color from front/rear
+        source=source)
+
+    p.legend.level = 'overlay'
+
+    wz = WheelZoomTool(maintain_focus=False, dimensions='width')
+    p.add_tools(wz)
+    p.toolbar.active_scroll = wz
+
+    p.hover.mode = 'vline'
+    p.hover.renderers = [line]
+    p.legend.location = 'bottom_right'
+
+    return p

--- a/dashboard/app/telemetry/speed.py
+++ b/dashboard/app/telemetry/speed.py
@@ -1,8 +1,9 @@
 import numpy as np
 
 from bokeh.models import ColumnDataSource
+from bokeh.models.annotations import Span
 from bokeh.models.ranges import Range1d
-from bokeh.models.tools import WheelZoomTool
+from bokeh.models.tools import CrosshairTool, WheelZoomTool
 from bokeh.palettes import Spectral11
 from bokeh.plotting import figure
 
@@ -54,6 +55,15 @@ def speed_figure(speed_data: list[float], sample_rate: float = 10.0) -> figure:
     wz = WheelZoomTool(maintain_focus=False, dimensions='width')
     p.add_tools(wz)
     p.toolbar.active_scroll = wz
+
+    s_current_time = Span(name='s_current_time_speed',
+                          location=0,
+                          dimension='height',
+                          line_color='#d0d0d0')
+    ch = CrosshairTool(dimensions='height', line_color='#d0d0d0',
+                       overlay=s_current_time)
+    p.add_tools(ch)
+    p.toolbar.active_inspect = ch
 
     p.hover.mode = 'vline'
     p.hover.renderers = [line]

--- a/dashboard/app/telemetry/speed.py
+++ b/dashboard/app/telemetry/speed.py
@@ -3,7 +3,7 @@ import numpy as np
 from bokeh.models import ColumnDataSource
 from bokeh.models.annotations import Span
 from bokeh.models.ranges import Range1d
-from bokeh.models.tools import CrosshairTool, WheelZoomTool
+from bokeh.models.tools import CrosshairTool, WheelPanTool, WheelZoomTool
 from bokeh.palettes import Spectral11
 from bokeh.plotting import figure
 
@@ -52,6 +52,8 @@ def speed_figure(speed_data: list[float], sample_rate: float = 10.0) -> figure:
 
     p.legend.level = 'overlay'
 
+    wp = WheelPanTool(dimension='width')
+    p.add_tools(wp)
     wz = WheelZoomTool(maintain_focus=False, dimensions='width')
     p.add_tools(wz)
     p.toolbar.active_scroll = wz

--- a/dashboard/app/telemetry/travel.py
+++ b/dashboard/app/telemetry/travel.py
@@ -6,7 +6,8 @@ from bokeh.models.annotations import BoxAnnotation, Label, Span
 from bokeh.models.axes import LinearAxis
 from bokeh.models.callbacks import CustomJS
 from bokeh.models.ranges import Range1d
-from bokeh.models.tools import BoxSelectTool, CrosshairTool, WheelZoomTool
+from bokeh.models.tools import (BoxSelectTool, CrosshairTool, WheelPanTool,
+                                WheelZoomTool)
 from bokeh.palettes import Spectral11
 from bokeh.plotting import figure
 
@@ -124,6 +125,8 @@ def travel_figure(telemetry: Telemetry, lod: int,
                  SST.update.plots(geometry['x0'], geometry['x1']);
                  '''))
 
+    wp = WheelPanTool(dimension='width')
+    p.add_tools(wp)
     wz = WheelZoomTool(maintain_focus=False, dimensions='width')
     p.add_tools(wz)
     p.toolbar.active_scroll = wz

--- a/dashboard/app/telemetry/velocity.py
+++ b/dashboard/app/telemetry/velocity.py
@@ -10,7 +10,7 @@ from bokeh.models.formatters import PrintfTickFormatter
 from bokeh.models.mappers import LinearColorMapper
 from bokeh.models.ranges import Range1d
 from bokeh.models.tickers import FixedTicker, SingleIntervalTicker
-from bokeh.models.tools import WheelZoomTool
+from bokeh.models.tools import CrosshairTool, WheelZoomTool
 from bokeh.palettes import Spectral11
 from bokeh.plotting import figure
 from scipy.stats import norm
@@ -80,6 +80,15 @@ def velocity_figure(telemetry: Telemetry, lod: int,
     wz = WheelZoomTool(maintain_focus=False, dimensions='width')
     p.add_tools(wz)
     p.toolbar.active_scroll = wz
+
+    s_current_time = Span(name='s_current_time_velocity',
+                          location=0,
+                          dimension='height',
+                          line_color='#d0d0d0')
+    ch = CrosshairTool(dimensions='height', line_color='#d0d0d0',
+                       overlay=s_current_time)
+    p.add_tools(ch)
+    p.toolbar.active_inspect = ch
 
     p.hover.mode = 'vline'
     p.hover.renderers = [line]

--- a/dashboard/app/telemetry/velocity.py
+++ b/dashboard/app/telemetry/velocity.py
@@ -10,7 +10,7 @@ from bokeh.models.formatters import PrintfTickFormatter
 from bokeh.models.mappers import LinearColorMapper
 from bokeh.models.ranges import Range1d
 from bokeh.models.tickers import FixedTicker, SingleIntervalTicker
-from bokeh.models.tools import CrosshairTool, WheelZoomTool
+from bokeh.models.tools import CrosshairTool, WheelPanTool, WheelZoomTool
 from bokeh.palettes import Spectral11
 from bokeh.plotting import figure
 from scipy.stats import norm
@@ -77,6 +77,8 @@ def velocity_figure(telemetry: Telemetry, lod: int,
         source=source)
     p.legend.level = 'overlay'
 
+    wp = WheelPanTool(dimension='width')
+    p.add_tools(wp)
     wz = WheelZoomTool(maintain_focus=False, dimensions='width')
     p.add_tools(wz)
     p.toolbar.active_scroll = wz

--- a/dashboard/frontend/src/index.js
+++ b/dashboard/frontend/src/index.js
@@ -5,6 +5,8 @@ var Layout = require("./views/Layout")
 var Dashboard = require("./views/Dashboard")
 var SST = require("./models/Global")
 
+window.SST = SST
+
 m.route.prefix = '#'
 m.route(document.body, "/dashboard", {
     "/dashboard": {
@@ -18,5 +20,3 @@ m.route(document.body, "/dashboard", {
         }
     },
 })
-
-window.SST = SST

--- a/dashboard/frontend/src/models/Global.js
+++ b/dashboard/frontend/src/models/Global.js
@@ -8,6 +8,54 @@ var SST = {
   setError: function(error) {
     Layout.error = error
   },
+  fitMapToTrack: function(lon, lat, start_idx, end_idx) {
+    const map = Bokeh.documents[0].get_model_by_name("map");
+    if (!map || start_idx >= end_idx) return;
+
+    let min_x = Infinity, max_x = -Infinity;
+    let min_y = Infinity, max_y = -Infinity;
+
+    for (let i = start_idx; i < end_idx; i++) {
+      if (lon[i] < min_x) min_x = lon[i];
+      if (lon[i] > max_x) max_x = lon[i];
+      if (lat[i] < min_y) min_y = lat[i];
+      if (lat[i] > max_y) max_y = lat[i];
+    }
+
+    let data_w = max_x - min_x;
+    let data_h = max_y - min_y;
+    const center_x = (min_x + max_x) / 2;
+    const center_y = (min_y + max_y) / 2;
+
+    // Add padding
+    data_w *= 1.1;
+    data_h *= 1.05;
+
+    // Ensure a minimum extent to avoid extreme zoom-in for very short segments
+    const MIN_EXTENT = 100;
+    if (data_w < MIN_EXTENT) data_w = MIN_EXTENT;
+    if (data_h < MIN_EXTENT) data_h = MIN_EXTENT;
+
+    // Get plot aspect ratio
+    let aspect = 1.0;
+    if (map.inner_height > 0) {
+      aspect = map.inner_width / map.inner_height;
+    }
+
+    let final_w, final_h;
+    if (data_w / data_h > aspect) {
+      final_w = data_w;
+      final_h = data_w / aspect;
+    } else {
+      final_h = data_h;
+      final_w = final_h * aspect;
+    }
+
+    map.x_range.start = center_x - final_w / 2;
+    map.x_range.end = center_x + final_w / 2;
+    map.y_range.start = center_y - final_h / 2;
+    map.y_range.end = center_y + final_h / 2;
+  },
   getCookie: function (name) {
     const value = `; ${document.cookie}`;
     const parts = value.split(`; ${name}=`);
@@ -171,17 +219,13 @@ var SST = {
     map: function(full_track, session_track) {
       const map = Bokeh.documents[0].get_model_by_name("map");
       if (session_track) {
-        const start_lon = session_track["lon"][0];
-        const start_lat = session_track["lat"][0];
-
         map.select_one("ds_track").data = full_track;
         map.select_one("ds_session").data = session_track;
 
-        const ratio = map.inner_height / map.inner_width;
-        map.x_range.start = start_lon - 600;
-        map.x_range.end = start_lon + 600;
-        map.y_range.start = start_lat - (600 * ratio);
-        map.y_range.end = start_lat + (600 * ratio);
+        // Fit map to entire session track
+        const lon = session_track["lon"];
+        const lat = session_track["lat"];
+        SST.fitMapToTrack(lon, lat, 0, lon.length);
 
         const start_point = map.select_one("start_point");
         start_point.size = 10

--- a/dashboard/frontend/src/models/Session.js
+++ b/dashboard/frontend/src/models/Session.js
@@ -139,6 +139,10 @@ var Session = {
       if (result !== undefined) {
         SST.update.map(result.full_track, result.session_track);
         Session.current.session_track = result.session_track
+        // Reload session to get new HTML with speed graph
+        if (window.SST.reloadSession) {
+          return window.SST.reloadSession()
+        }
       }
     })
     .catch(function(error) {

--- a/dashboard/frontend/src/views/Dashboard.js
+++ b/dashboard/frontend/src/views/Dashboard.js
@@ -10,13 +10,13 @@ var SingleSuspensionTabs = {
       m("input.radiotab", {name: "tabs", tabindex: "1", type: "radio", id: "tabone", checked: "checked"}),
       m("label.label", {style: "grid-column: 1", for: "tabone"}, "Spring rate"),
       m(".panel springrate", {tabindex: "1"}, [
-        m(".travel-hist", m.trust(Session.current.divs[5])),
-        m(".fft", m.trust(Session.current.divs[6])),
+        m(".travel-hist", m.trust(Session.current.divs[6])),
+        m(".fft", m.trust(Session.current.divs[7])),
       ]),
       m("input.radiotab", {name: "tabs", tabindex: "1", type: "radio", id: "tabtwo"}),
       m("label.label", {style: "grid-column: 2", for: "tabtwo"}, "Damping"),
       m(".panel damping", {tabindex: "1"}, [
-        m(".velocity-hist", m.trust(Session.current.divs[7])),
+        m(".velocity-hist", m.trust(Session.current.divs[8])),
       ]),
     ])
   }
@@ -32,22 +32,22 @@ var DualSuspensionTabs = {
       m("input.radiotab", {name: "tabs", tabindex: "1", type: "radio", id: "tabone"}),
       m("label.label", {style: "grid-column: 1", for: "tabone"}, "Spring rate"),
       m(".panel springrate", {tabindex: "1"}, [
-        m(".front-travel-hist", m.trust(Session.current.divs[5])),
-        m(".rear-travel-hist", m.trust(Session.current.divs[8])),
-        m(".front-fft", m.trust(Session.current.divs[6])),
-        m(".rear-fft", m.trust(Session.current.divs[9])),
+        m(".front-travel-hist", m.trust(Session.current.divs[6])),
+        m(".rear-travel-hist", m.trust(Session.current.divs[9])),
+        m(".front-fft", m.trust(Session.current.divs[7])),
+        m(".rear-fft", m.trust(Session.current.divs[10])),
       ]),
       m("input.radiotab", {name: "tabs", tabindex: "1", type: "radio", id: "tabtwo"}),
       m("label.label", {style: "grid-column: 2", for: "tabtwo"}, "Damping"),
       m(".panel damping", {tabindex: "1"}, [
-        m(".front-velocity-hist", m.trust(Session.current.divs[7])),
-        m(".rear-velocity-hist", m.trust(Session.current.divs[10])),
+        m(".front-velocity-hist", m.trust(Session.current.divs[8])),
+        m(".rear-velocity-hist", m.trust(Session.current.divs[11])),
       ]),
       m("input.radiotab", {name: "tabs", tabindex: "1", type: "radio", id: "tabthree"}),
       m("label.label", {style: "grid-column: 3", for: "tabthree"}, "Balance"),
       m(".panel balance", {tabindex: "1"}, [
-        m(".balance-compression", m.trust(Session.current.divs[11])),
-        m(".balance-rebound", m.trust(Session.current.divs[12])),
+        m(".balance-compression", m.trust(Session.current.divs[12])),
+        m(".balance-rebound", m.trust(Session.current.divs[13])),
       ]),
     ])
   }
@@ -100,19 +100,26 @@ module.exports = {
     m.redraw()
   },
   view: function() {
-    return Session.current.loaded ? m(".container", {id: "page-content"}, [
+    var hasVidMap = Session.current.session_track || VideoPlayer.loaded;
+    var hasSpeed = Session.current.has_speed;
+
+    return Session.current.loaded ? m(".container", {
+      id: "page-content",
+      class: hasSpeed ? "has-speed" : ""
+    }, [
       m(".video-map", [
-        m(".map", {style: VideoPlayer.loaded ? "" : "height: 100%"}, m.trust(Session.current.divs[2])),
+        m(".map", {style: VideoPlayer.loaded ? "" : "height: 100%"}, m.trust(Session.current.divs[3])),
         m(VideoPlayer),
       ]),
       m("div", {
-        class: Session.current.session_track || VideoPlayer.loaded ? "travel" : "travel novidmap"
+        class: hasVidMap ? "travel" : "travel novidmap"
       }, m.trust(Session.current.divs[0])),
       m("div", {
-        class: Session.current.session_track || VideoPlayer.loaded ? "velocity" : "velocity novidmap"
+        class: hasVidMap ? "velocity" : "velocity novidmap"
       }, m.trust(Session.current.divs[1])),
-      m(".lr", m.trust(Session.current.divs[3])),
-      m(".sw", m.trust(Session.current.divs[4])),
+      hasSpeed ? m(".speed", m.trust(Session.current.divs[2])) : null,
+      m(".lr", m.trust(Session.current.divs[4])),
+      m(".sw", m.trust(Session.current.divs[5])),
       m(".description", m(Notes)),
       Session.current.suspension_count == 2 ? m(DualSuspensionTabs) : m(SingleSuspensionTabs),
     ]) : m("div", "SESSION IS LOADING")

--- a/dashboard/frontend/src/views/Dashboard.js
+++ b/dashboard/frontend/src/views/Dashboard.js
@@ -71,16 +71,37 @@ function waitForDivs(divIds, callback) {
   observer.observe(document.body, { childList: true, subtree: true });
 }
 
+function clearBokeh() {
+  if (Bokeh.documents.length != 0) {
+    Bokeh.documents[0].clear()
+    delete Bokeh.documents[0]
+    Bokeh.documents.splice(0)
+  }
+}
+
+function initBokeh() {
+  m.redraw()
+  waitForDivs(Session.current.divIds, () => {eval(Session.current.script)})
+}
+
 module.exports = {
   oncreate: function(vnode) {
+    // Register reload handler for use by Session.importGPX
+    window.SST.reloadSession = function() {
+      clearBokeh()
+      return Session.load(Session.current.id)
+        .then(() => {
+          initBokeh()
+        })
+    }
+
     // Load new session and update dashboard
     Session.load(vnode.attrs.key)
     .then(() => {
       document.getElementById("layout-stylesheet").setAttribute("href",
         Session.current.suspension_count == 1 ? "static/layout-single.css" : "static/layout-double.css")
       document.title = `Sufni Suspenion Telemetry (${Session.current.name})`
-      m.redraw()
-      waitForDivs(Session.current.divIds, () => {eval(Session.current.script)})
+      initBokeh()
     })
     .catch((error) => {
       if (error.code == 401) {
@@ -89,11 +110,8 @@ module.exports = {
     })
   },
   onremove: function() {
-    if (Bokeh.documents.length != 0) {
-      Bokeh.documents[0].clear()
-      delete Bokeh.documents[0]
-      Bokeh.documents.splice(0)
-    }
+    clearBokeh()
+    window.SST.reloadSession = null
     Session.current = {loaded: false}
     document.getElementById("layout-stylesheet").setAttribute("href", "")
     document.title = "Sufni Suspenion Telemetry"

--- a/dashboard/migrations/versions/a1b2c3d4e5f6_add_speed_to_session_html.py
+++ b/dashboard/migrations/versions/a1b2c3d4e5f6_add_speed_to_session_html.py
@@ -1,0 +1,26 @@
+"""Add speed column to session_html
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5c40381ea62d
+Create Date: 2024-12-13 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = '5c40381ea62d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('session_html', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('speed', sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('session_html', schema=None) as batch_op:
+        batch_op.drop_column('speed')


### PR DESCRIPTION
This PR calculates speed when importing GPX tracks and plots them together with travel & velocity, as I have found it helpful when interpreting and comparing data from repeated sections.

It is [DRAFT] as the speed calculations do not seem right, compared to Garmin Connect and looks like the graph is time shifted.

For existing sessions the speed is not calculated and shown from the Mercator stored data, but if the track is re-uploaded it will be recalculated.
It also adds crosshairs for velocity & speed and links them to the travel crosshair. 

<img width="2554" height="1303" alt="image" src="https://github.com/user-attachments/assets/19ce86f4-8581-48ea-975e-b757cac9ade4" />

P.S. I have very little experience with Python and extremely little with JS, so let me know if something looks bad. I had a lot of trouble triggering session reload and UI redraw after GPX is uploaded.