### PR TITLE
TLV format for SST files in firmware and dashboard

### DIFF
--- a/dashboard/app/api/session/routes.py
+++ b/dashboard/app/api/session/routes.py
@@ -143,14 +143,14 @@ def filter(id: uuid.UUID):
     d = msgpack.unpackb(entity.data)
     t = dataclass_from_dict(Telemetry, d)
 
-    start, end = _extract_range(t.SampleRate)
+    start, end = _extract_range(t.TelemetrySampleRate)
     count = len(t.Front.Travel if t.Front.Present else t.Rear.Travel)
     if not _validate_range(start, end, count):
         start = None
         end = None
 
     updated_data = {'front': None, 'rear': None}
-    tick = 1.0 / t.SampleRate
+    tick = 1.0 / t.TelemetrySampleRate
     if t.Front.Present:
         f_strokes = _filter_strokes(t.Front.Strokes, start, end)
         updated_data['front'] = _update_stroke_based(f_strokes, t.Front)
@@ -344,11 +344,11 @@ def session_html(session_id: uuid.UUID):
         suspension_count += 1
 
     record_num = len(t.Front.Travel) if t.Front.Present else len(t.Rear.Travel)
-    elapsed_time = record_num / t.SampleRate
+    elapsed_time = record_num / t.TelemetrySampleRate
     start_time = session.timestamp
     end_time = start_time + elapsed_time
-    full_track, session_track = track_data(track.track if track else None,
-                                           start_time, end_time)
+    full_track, session_track, markers_track = track_data(
+        track.track if track else None, start_time, end_time, t.Markers)
 
     response = jsonify(
         id=session.id,
@@ -369,6 +369,7 @@ def session_html(session_id: uuid.UUID):
         suspension_count=suspension_count,
         full_track=full_track,
         session_track=session_track,
+        markers_track=markers_track,
         script=components_script,
         divs=components_divs,
         full_access=full_access,
@@ -388,13 +389,14 @@ def upload_gpx(id: uuid.UUID):
     d = msgpack.unpackb(session.data)
     t = dataclass_from_dict(Telemetry, d)
     record_num = len(t.Front.Travel) if t.Front.Present else len(t.Rear.Travel)
-    elapsed_time = record_num / t.SampleRate
+    elapsed_time = record_num / t.TelemetrySampleRate
     start_time = session.timestamp
     end_time = start_time + elapsed_time
 
     track_dict = gpx_to_dict(request.data)
     ts, tf = track_dict['time'][0], track_dict['time'][-1]
-    full_track, session_track = track_data(track_dict, start_time, end_time)
+    full_track, session_track, markers_track = track_data(
+        track_dict, start_time, end_time, t.Markers)
     if session_track is None:
         return jsonify(msg="Track is not applicable!"), status.BAD_REQUEST
 
@@ -421,5 +423,6 @@ def upload_gpx(id: uuid.UUID):
     db.session.execute(stmt_update)
     db.session.commit()
 
-    data = dict(full_track=full_track, session_track=session_track)
+    data = dict(full_track=full_track, session_track=session_track,
+                markers_track=markers_track)
     return jsonify(data), status.OK

--- a/dashboard/app/telemetry/map.py
+++ b/dashboard/app/telemetry/map.py
@@ -47,6 +47,29 @@ def _session_track(start: int, end: int, t: np.array, track: dict) -> (
     return dict(lon=list(y[0, :]), lat=list(y[1, :]))
 
 
+def _markers_track(markers: list[float], start: int, end: int, t: np.array,
+                   track: dict) -> dict[str, list[float]]:
+    if not markers:
+        return dict(lat=[], lon=[])
+
+    session_indices = np.where(np.logical_and(t >= start, t <= end))
+    if len(session_indices[0]) == 0:
+        return dict(lat=[], lon=[])
+
+    start_idx = session_indices[0][0]
+    end_idx = session_indices[0][-1] + 1
+
+    session_lon = np.array(track['lon'][start_idx:end_idx])
+    session_lat = np.array(track['lat'][start_idx:end_idx])
+    session_time = np.array(t[start_idx:end_idx]) - start
+    session_time[0] = 0
+
+    yi = np.array([session_lon, session_lat])
+    y = pchip_interpolate(session_time, yi, markers, axis=1)
+
+    return dict(lon=list(y[0, :]), lat=list(y[1, :]))
+
+
 def gpx_to_dict(gpx_data: str) -> dict[str, Any]:
     gpx_dict = dict(lat=[], lon=[], ele=[], time=[])
     gpx_file = io.BytesIO(gpx_data)
@@ -63,10 +86,11 @@ def gpx_to_dict(gpx_data: str) -> dict[str, Any]:
     return gpx_dict
 
 
-def track_data(track: str, start_timestamp: int, end_timestamp: int) -> (
-               dict[str, Any], dict[str, list[float]]):
+def track_data(track: str, start_timestamp: int, end_timestamp: int,
+               markers: list[float] = None) -> (
+               dict[str, Any], dict[str, list[float]], dict[str, list[float]]):
     if not track:
-        return None, None
+        return None, None, None
 
     if type(track) is str:
         full_track = json.loads(track)
@@ -84,13 +108,19 @@ def track_data(track: str, start_timestamp: int, end_timestamp: int) -> (
                                    end_timestamp,
                                    timestamps,
                                    full_track)
+    markers_track = _markers_track(markers,
+                                   start_timestamp,
+                                   end_timestamp,
+                                   timestamps,
+                                   full_track)
 
-    return full_track, session_track
+    return full_track, session_track, markers_track
 
 
 def map_figure() -> (figure, CustomJS):
     ds_track = ColumnDataSource(name='ds_track', data=dict(lat=[], lon=[]))
     ds_session = ColumnDataSource(name='ds_session', data=dict(lat=[], lon=[]))
+    ds_markers = ColumnDataSource(name='ds_markers', data=dict(lat=[], lon=[]))
 
     p = figure(
         name='map',
@@ -121,6 +151,9 @@ def map_figure() -> (figure, CustomJS):
                 line_color='black', fill_color='#E74C3C', fill_alpha=0.8)
     p.add_glyph(cs)
     p.add_glyph(ce)
+
+    p.circle(name='markers', x='lon', y='lat', source=ds_markers, radius=10,
+             line_color='black', fill_color='#E74C3C', fill_alpha=0.8)
 
     pos_marker = Circle(name="pos_marker", x=0, y=0, radius=13,
                         line_color='black', fill_color='gray')

--- a/dashboard/app/telemetry/psst.py
+++ b/dashboard/app/telemetry/psst.py
@@ -77,12 +77,13 @@ class Suspension:
 class Telemetry:
     Name: str
     Version: int
-    SampleRate: int
+    TelemetrySampleRate: int
     Timestamp: int
     Front: Suspension
     Rear: Suspension
     Linkage: Linkage
     Airtimes: list[Airtime]
+    Markers: list[float]
 
     def __post_init__(self):
         self.Airtimes = [dataclass_from_dict(Airtime, d) for d in self.Airtimes]

--- a/dashboard/app/telemetry/session_html.py
+++ b/dashboard/app/telemetry/session_html.py
@@ -36,7 +36,7 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
     d = msgpack.unpackb(session.data)
     telemetry = dataclass_from_dict(Telemetry, d)
 
-    tick = 1.0 / telemetry.SampleRate  # time step length in seconds
+    tick = 1.0 / telemetry.TelemetrySampleRate  # time step length in seconds
 
     if telemetry.Front.Present:
         p_front_travel_hist = travel_histogram_figure(
@@ -88,8 +88,10 @@ def create_cache(session_id: uuid.UUID, lod: int, hst: int):
             rear_color,
             "Frequencies (rear)")
 
-    p_travel = travel_figure(telemetry, lod, front_color, rear_color)
-    p_velocity = velocity_figure(telemetry, lod, front_color, rear_color)
+    p_travel = travel_figure(telemetry, lod, front_color, rear_color,
+                             telemetry.Markers)
+    p_velocity = velocity_figure(telemetry, lod, front_color, rear_color,
+                                 telemetry.Markers)
     p_travel.x_range.js_link('start', p_velocity.x_range, 'start')
     p_travel.x_range.js_link('end', p_velocity.x_range, 'end')
     p_velocity.x_range.js_link('start', p_travel.x_range, 'start')

--- a/dashboard/app/telemetry/travel.py
+++ b/dashboard/app/telemetry/travel.py
@@ -17,10 +17,11 @@ HISTOGRAM_RANGE_MULTIPLIER = 1.3
 
 
 def travel_figure(telemetry: Telemetry, lod: int,
-                  front_color: tuple[str], rear_color: tuple[str]) -> figure:
+                  front_color: tuple[str], rear_color: tuple[str],
+                  markers: list[float]) -> figure:
     length = len(telemetry.Front.Travel if telemetry.Front.Present else
                  telemetry.Rear.Travel)
-    time = np.around(np.arange(0, length, lod) / telemetry.SampleRate, 4)
+    time = np.around(np.arange(0, length, lod) / telemetry.TelemetrySampleRate, 4)
     front_max = telemetry.Linkage.MaxFrontTravel
     rear_max = telemetry.Linkage.MaxRearTravel
 
@@ -53,6 +54,12 @@ def travel_figure(telemetry: Telemetry, lod: int,
         output_backend='webgl')
 
     _add_airtime_labels(p, telemetry.Airtimes)
+
+    if markers:
+        for marker in markers:
+            p.add_layout(Span(location=marker, dimension='height',
+                              line_color='red', line_dash='dashed',
+                              line_width=2))
 
     p.extra_y_ranges = {'rear': Range1d(start=rear_max, end=0)}
     p.add_layout(LinearAxis(y_range_name='rear'), 'right')

--- a/dashboard/app/telemetry/velocity.py
+++ b/dashboard/app/telemetry/velocity.py
@@ -25,10 +25,11 @@ HISTOGRAM_RANGE_LOW = -HISTOGRAM_RANGE_HIGH
 
 
 def velocity_figure(telemetry: Telemetry, lod: int,
-                    front_color: tuple[str], rear_color: tuple[str]) -> figure:
+                    front_color: tuple[str], rear_color: tuple[str],
+                    markers: list[float]) -> figure:
     length = len(telemetry.Front.Velocity if telemetry.Front.Present else
                  telemetry.Rear.Velocity)
-    time = np.around(np.arange(0, length, lod) / telemetry.SampleRate, 4)
+    time = np.around(np.arange(0, length, lod) / telemetry.TelemetrySampleRate, 4)
 
     if telemetry.Front.Present:
         vf_lod = np.around(telemetry.Front.Velocity[::lod], 4) / 1000
@@ -62,6 +63,12 @@ def velocity_figure(telemetry: Telemetry, lod: int,
         output_backend='webgl')
 
     p.x_range = Range1d(0, time[-1], bounds='auto')
+
+    if markers:
+        for marker in markers:
+            p.add_layout(Span(location=marker, dimension='height',
+                              line_color='red', line_dash='dashed',
+                              line_width=2))
 
     line = p.line(
         't', 'f',

--- a/dashboard/frontend/src/models/Global.js
+++ b/dashboard/frontend/src/models/Global.js
@@ -18,7 +18,8 @@ var SST = {
     VideoPlayer.travelSpan = Bokeh.documents[0].get_model_by_name("s_current_time")
 
     // Map
-    SST.update.map(Session.current.full_track, Session.current.session_track)
+    SST.update.map(Session.current.full_track, Session.current.session_track,
+                   Session.current.markers_track)
 
     // Disable tools on mobile
     if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
@@ -168,7 +169,7 @@ var SST = {
       p.select_one("ds_r").data = u.r_data;
       p.x_range.end = u.range_end;
     },
-    map: function(full_track, session_track) {
+    map: function(full_track, session_track, markers_track) {
       const map = Bokeh.documents[0].get_model_by_name("map");
       if (session_track) {
         const start_lon = session_track["lon"][0];
@@ -176,6 +177,7 @@ var SST = {
 
         map.select_one("ds_track").data = full_track;
         map.select_one("ds_session").data = session_track;
+        map.select_one("ds_markers").data = markers_track;
 
         const ratio = map.inner_height / map.inner_width;
         map.x_range.start = start_lon - 600;

--- a/dashboard/frontend/src/models/Session.js
+++ b/dashboard/frontend/src/models/Session.js
@@ -137,8 +137,10 @@ var Session = {
     })
     .then(function(result) {
       if (result !== undefined) {
-        SST.update.map(result.full_track, result.session_track);
+        SST.update.map(result.full_track, result.session_track,
+                       result.markers_track);
         Session.current.session_track = result.session_track
+        Session.current.markers_track = result.markers_track
       }
     })
     .catch(function(error) {

--- a/firmware/src/fw/main.c
+++ b/firmware/src/fw/main.c
@@ -38,6 +38,7 @@
 #include "hardware_config.h"
 
 static volatile enum state state;
+static volatile bool marker_pending = false;
 
 static uint32_t scb_orig;
 static uint32_t clock0_orig;
@@ -167,18 +168,31 @@ struct record databuffer2[BUFFER_SIZE];
 struct record *active_buffer = databuffer1;
 uint16_t count = 0;
 
+static void dump_active_buffer(uint16_t size) {
+    multicore_fifo_push_blocking(DUMP);
+    multicore_fifo_push_blocking(size);
+    multicore_fifo_push_blocking((uintptr_t)active_buffer);
+    active_buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
+}
+
 static bool data_acquisition_cb(repeating_timer_t *rt) {
     if (count == BUFFER_SIZE) {
+        dump_active_buffer(BUFFER_SIZE);
         count = 0;
-        multicore_fifo_push_blocking(DUMP);
-        multicore_fifo_push_blocking((uintptr_t)active_buffer);
-        active_buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
     }
 
     active_buffer[count].fork_angle = fork_sensor.measure(&fork_sensor);
     active_buffer[count].shock_angle = shock_sensor.measure(&shock_sensor);
 
     count += 1;
+
+    if (marker_pending) {
+        dump_active_buffer(count);
+        multicore_fifo_push_blocking(MARKER);
+
+        count = 0;
+        marker_pending = false;
+    }
 
     return state == RECORD; // keep repeating if we are still recording
 }
@@ -283,10 +297,24 @@ static int open_datafile() {
         return fr;
     }
 
-    struct header h = {"SST", 3, SAMPLE_RATE, rtc_timestamp()};
+    struct header h = {"SST", 4, 0, rtc_timestamp()};
     f_write(&recording, &h, sizeof(struct header), NULL);
 
+    struct chunk_header ch = {CHUNK_TYPE_RATES, sizeof(struct rate_entry)};
+    f_write(&recording, &ch, sizeof(struct chunk_header), NULL);
+    struct rate_entry re = {CHUNK_TYPE_TELEMETRY, SAMPLE_RATE};
+    f_write(&recording, &re, sizeof(struct rate_entry), NULL);
+
     return index;
+}
+
+static void write_telemetry_chunk(uint16_t size, struct record *buffer) {
+    struct chunk_header ch;
+    ch.type = CHUNK_TYPE_TELEMETRY;
+    ch.length = size * sizeof(struct record);
+    f_write(&recording, &ch, sizeof(struct chunk_header), NULL);
+    f_write(&recording, buffer, ch.length, NULL);
+    f_sync(&recording);
 }
 
 static void data_storage_core1() {
@@ -297,6 +325,8 @@ static void data_storage_core1() {
     enum command cmd;
     uint16_t size;
     struct record *buffer;
+    struct chunk_header ch;
+
     while (true) {
         cmd = (enum command)multicore_fifo_pop_blocking();
         switch (cmd) {
@@ -307,16 +337,21 @@ static void data_storage_core1() {
                 multicore_fifo_push_blocking((uintptr_t)databuffer2);
                 break;
             case DUMP:
+                size = (uint16_t)multicore_fifo_pop_blocking();
                 buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
                 multicore_fifo_push_blocking((uintptr_t)buffer);
-                f_write(&recording, buffer, sizeof(struct record) * BUFFER_SIZE, NULL);
+                write_telemetry_chunk(size, buffer);
+                break;
+            case MARKER:
+                ch.type = CHUNK_TYPE_MARKER;
+                ch.length = 0;
+                f_write(&recording, &ch, sizeof(struct chunk_header), NULL);
                 f_sync(&recording);
                 break;
             case FINISH:
                 size = (uint16_t)multicore_fifo_pop_blocking();
                 buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
-                f_write(&recording, buffer, sizeof(struct record) * size, NULL);
-                f_sync(&recording);
+                write_telemetry_chunk(size, buffer);
                 f_close(&recording);
                 break;
         }
@@ -714,6 +749,9 @@ static void on_right_press(void *user_data) {
     switch (state) {
         case IDLE:
             state = SLEEP;
+            break;
+        case RECORD:
+            marker_pending = true;
             break;
         case SERVE_TCP:
             tcpserver_finish(&server);

--- a/firmware/src/fw/main.c
+++ b/firmware/src/fw/main.c
@@ -752,6 +752,7 @@ static void on_right_press(void *user_data) {
             break;
         case RECORD:
             marker_pending = true;
+            LOG("REC", "Marker set\n");
             break;
         case SERVE_TCP:
             tcpserver_finish(&server);

--- a/firmware/src/fw/sst.h
+++ b/firmware/src/fw/sst.h
@@ -24,10 +24,24 @@ enum state {
 };
 #define STATES_COUNT 13
 
+#define CHUNK_TYPE_RATES 0x00
+#define CHUNK_TYPE_TELEMETRY 0x01
+#define CHUNK_TYPE_MARKER 0x02
+
+struct chunk_header {
+    uint8_t type;
+    uint16_t length;
+} __attribute__((packed));
+
+struct rate_entry {
+    uint8_t type;
+    uint16_t rate;
+} __attribute__((packed));
+
 struct header {
     char magic[3];
     uint8_t version;
-    uint16_t sample_rate;
+    uint32_t padding;
     time_t timestamp;
 };
 
@@ -36,7 +50,7 @@ struct record {
     uint16_t shock_angle;
 };
 
-enum command { OPEN, DUMP, FINISH };
+enum command { OPEN, DUMP, FINISH, MARKER };
 
 #define BUFFER_SIZE 2048
 #define FILENAME_LENGTH                                                                                                \

--- a/firmware/src/ui/pushbutton.c
+++ b/firmware/src/ui/pushbutton.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "pushbutton.h"
+#include "../util/log.h"
 
 static struct button *buttons[28] = {NULL};
 
@@ -13,6 +14,7 @@ static int64_t longpress_callback(alarm_id_t id, void *user_data) {
     if (state == btn->state) {
         btn->alarm = -1;
         if (btn->onlongpress != NULL) {
+            LOG("BUTTON", "Button %u long press\n", btn->gpio);
             btn->onlongpress(btn->user_data);
         }
     }
@@ -30,6 +32,7 @@ static int64_t debounce_callback(alarm_id_t id, void *user_data) {
             cancel_alarm(btn->alarm);
             btn->alarm = -1;
             if (btn->onpress != NULL) {
+                LOG("BUTTON", "Button %u press\n", btn->gpio);
                 btn->onpress(btn->user_data);
             }
         }

--- a/gosst/cmd/gosst-file/gosst-file.go
+++ b/gosst/cmd/gosst-file/gosst-file.go
@@ -55,7 +55,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	front, rear, meta, err := sst.ProcessRaw(tb)
+	front, rear, markers, meta, err := sst.ProcessRaw(tb)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -65,7 +65,7 @@ func main() {
 		FrontCalibration: fcal,
 		RearCalibration:  rcal,
 	}
-	pd, err := psst.ProcessRecording(front, rear, meta, &setup)
+	pd, err := psst.ProcessRecording(front, rear, markers, meta, &setup)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/gosst/cmd/gosst-http/gosst-http.go
+++ b/gosst/cmd/gosst-http/gosst-http.go
@@ -135,13 +135,13 @@ func (this *RequestHandler) PutSession(c *gin.Context) {
 		return
 	}
 
-	front, rear, meta, err := sst.ProcessRaw(sst_data)
+	front, rear, markers, meta, err := sst.ProcessRaw(sst_data)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	meta.Name = session.Name
-	pd, err := psst.ProcessRecording(front, rear, meta, setup)
+	pd, err := psst.ProcessRecording(front, rear, markers, meta, setup)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -200,17 +200,17 @@ func (this *RequestHandler) PutNormalizedSession(c *gin.Context) {
 		return
 	}
 	meta := psst.Meta{
-		Name:       session.Name,
-		Version:    255,
-		SampleRate: session.SampleRate,
-		Timestamp:  session.Timestamp,
+		Name:                session.Name,
+		Version:             255,
+		TelemetrySampleRate: session.SampleRate,
+		Timestamp:           session.Timestamp,
 	}
 	setup := &psst.SetupData{
 		Linkage:          linkage,
 		FrontCalibration: fcal,
 		RearCalibration:  rcal,
 	}
-	pd, err := psst.ProcessRecording(front, rear, meta, setup)
+	pd, err := psst.ProcessRecording(front, rear, nil, meta, setup)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/gosst/cmd/gosst-tcp/gosst-tcp.go
+++ b/gosst/cmd/gosst-tcp/gosst-tcp.go
@@ -51,12 +51,12 @@ func putSession(db *sql.DB, h codec.Handle, board [10]byte, server, name string,
 		return uuid.Nil, err
 	}
 
-	front, rear, meta, err := sst.ProcessRaw(sst_data)
+	front, rear, markers, meta, err := sst.ProcessRaw(sst_data)
 	if err != nil {
 		return uuid.Nil, err
 	}
 	meta.Name = name
-	pd, err := psst.ProcessRecording(front, rear, meta, setup)
+	pd, err := psst.ProcessRecording(front, rear, markers, meta, setup)
 	if err != nil {
 		return uuid.Nil, err
 	}

--- a/gosst/formats/psst/airtimes.go
+++ b/gosst/formats/psst/airtimes.go
@@ -15,8 +15,8 @@ func (this *Processed) airtimes() {
 						r.airCandidate = false
 
 						at := &airtime{
-							Start: float64(min(f.Start, r.Start)) / float64(this.SampleRate),
-							End:   float64(min(f.End, r.End)) / float64(this.SampleRate),
+							Start: float64(min(f.Start, r.Start)) / float64(this.TelemetrySampleRate),
+							End:   float64(min(f.End, r.End)) / float64(this.TelemetrySampleRate),
 						}
 						this.Airtimes = append(this.Airtimes, at)
 						break
@@ -31,8 +31,8 @@ func (this *Processed) airtimes() {
 				rmean := stat.Mean(this.Rear.Travel[f.Start:f.End+1], nil)
 				if (fmean+rmean)/2 <= maxMean*AIRTIME_TRAVEL_MEAN_THRESHOLD_RATIO {
 					at := &airtime{
-						Start: float64(f.Start) / float64(this.SampleRate),
-						End:   float64(f.End) / float64(this.SampleRate),
+						Start: float64(f.Start) / float64(this.TelemetrySampleRate),
+						End:   float64(f.End) / float64(this.TelemetrySampleRate),
 					}
 					this.Airtimes = append(this.Airtimes, at)
 				}
@@ -44,8 +44,8 @@ func (this *Processed) airtimes() {
 				rmean := stat.Mean(this.Rear.Travel[r.Start:r.End+1], nil)
 				if (fmean+rmean)/2 <= maxMean*AIRTIME_TRAVEL_MEAN_THRESHOLD_RATIO {
 					at := &airtime{
-						Start: float64(r.Start) / float64(this.SampleRate),
-						End:   float64(r.End) / float64(this.SampleRate),
+						Start: float64(r.Start) / float64(this.TelemetrySampleRate),
+						End:   float64(r.End) / float64(this.TelemetrySampleRate),
 					}
 					this.Airtimes = append(this.Airtimes, at)
 				}
@@ -55,8 +55,8 @@ func (this *Processed) airtimes() {
 		for _, f := range this.Front.Strokes.idlings {
 			if f.airCandidate {
 				at := &airtime{
-					Start: float64(f.Start) / float64(this.SampleRate),
-					End:   float64(f.End) / float64(this.SampleRate),
+					Start: float64(f.Start) / float64(this.TelemetrySampleRate),
+					End:   float64(f.End) / float64(this.TelemetrySampleRate),
 				}
 				this.Airtimes = append(this.Airtimes, at)
 			}
@@ -65,8 +65,8 @@ func (this *Processed) airtimes() {
 		for _, r := range this.Rear.Strokes.idlings {
 			if r.airCandidate {
 				at := &airtime{
-					Start: float64(r.Start) / float64(this.SampleRate),
-					End:   float64(r.End) / float64(this.SampleRate),
+					Start: float64(r.Start) / float64(this.TelemetrySampleRate),
+					End:   float64(r.End) / float64(this.TelemetrySampleRate),
 				}
 				this.Airtimes = append(this.Airtimes, at)
 			}

--- a/gosst/formats/psst/psst.go
+++ b/gosst/formats/psst/psst.go
@@ -65,10 +65,10 @@ type Number interface {
 }
 
 type Meta struct {
-	Name       string
-	Version    uint8
-	SampleRate uint16
-	Timestamp  int64
+	Name                string
+	Version             uint8
+	TelemetrySampleRate uint16
+	Timestamp           int64
 }
 
 type SetupData struct {
@@ -83,6 +83,7 @@ type Processed struct {
 	Rear     suspension
 	Linkage  Linkage
 	Airtimes []*airtime
+	Markers  []float64
 }
 
 func (this *Linkage) ProcessRawData() error {
@@ -150,12 +151,13 @@ func (e *RecordCountMismatchError) Error() string {
 	return "Front and rear record counts are not equal"
 }
 
-func ProcessRecording[T Number](front, rear []T, meta Meta, setup *SetupData) (*Processed, error) {
+func ProcessRecording[T Number](front, rear []T, markers []float64, meta Meta, setup *SetupData) (*Processed, error) {
 	var pd Processed
 	pd.Meta = meta
 	pd.Front.Calibration = *setup.FrontCalibration
 	pd.Rear.Calibration = *setup.RearCalibration
 	pd.Linkage = *setup.Linkage
+	pd.Markers = markers
 
 	fc := len(front)
 	rc := len(rear)
@@ -170,7 +172,7 @@ func ProcessRecording[T Number](front, rear []T, meta Meta, setup *SetupData) (*
 
 	t := make([]float64, record_count)
 	for i := range t {
-		t[i] = 1.0 / float64(pd.SampleRate) * float64(i)
+		t[i] = 1.0 / float64(pd.TelemetrySampleRate) * float64(i)
 	}
 	filter, _ := savitzkygolay.NewFilter(51, 1, 3)
 
@@ -202,7 +204,7 @@ func ProcessRecording[T Number](front, rear []T, meta Meta, setup *SetupData) (*
 		vbinsFine, dvFine := digitizeVelocity(v, VELOCITY_HIST_STEP_FINE)
 		pd.Front.FineVelocityBins = vbinsFine
 
-		strokes := filterStrokes(v, pd.Front.Travel, pd.Linkage.MaxFrontTravel, pd.SampleRate)
+		strokes := filterStrokes(v, pd.Front.Travel, pd.Linkage.MaxFrontTravel, pd.TelemetrySampleRate)
 		pd.Front.Strokes.categorize(strokes, pd.Front.Travel, pd.Linkage.MaxFrontTravel)
 		if len(pd.Front.Strokes.Compressions) == 0 && len(pd.Front.Strokes.Rebounds) == 0 {
 			pd.Front.Present = false
@@ -235,7 +237,7 @@ func ProcessRecording[T Number](front, rear []T, meta Meta, setup *SetupData) (*
 		vbinsFine, dvFine := digitizeVelocity(v, VELOCITY_HIST_STEP_FINE)
 		pd.Rear.FineVelocityBins = vbinsFine
 
-		strokes := filterStrokes(v, pd.Rear.Travel, pd.Linkage.MaxRearTravel, pd.SampleRate)
+		strokes := filterStrokes(v, pd.Rear.Travel, pd.Linkage.MaxRearTravel, pd.TelemetrySampleRate)
 		pd.Rear.Strokes.categorize(strokes, pd.Rear.Travel, pd.Linkage.MaxRearTravel)
 		if len(pd.Rear.Strokes.Compressions) == 0 && len(pd.Rear.Strokes.Rebounds) == 0 {
 			pd.Rear.Present = false

--- a/gosst/formats/sst/sst.go
+++ b/gosst/formats/sst/sst.go
@@ -3,16 +3,33 @@ package sst
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"io"
 
 	psst "gosst/formats/psst"
 )
 
+const (
+	ChunkTypeRates     = 0x00
+	ChunkTypeTelemetry = 0x01
+	ChunkTypeMarker    = 0x02
+)
+
 type header struct {
-	Magic      [3]byte
-	Version    uint8
-	SampleRate uint16
-	Padding    uint16
-	Timestamp  int64
+	Magic     [3]byte
+	Version   uint8
+	Padding   uint32
+	Timestamp int64
+}
+
+type chunkHeader struct {
+	Type   uint8
+	Length uint16
+}
+
+type rateEntry struct {
+	Type uint8
+	Rate uint16
 }
 
 type record struct {
@@ -26,29 +43,86 @@ func (e *NotSSTError) Error() string {
 	return "Data is not SST format"
 }
 
-func ProcessRaw(sst_data []byte) (front, rear []uint16, meta psst.Meta, err error) {
+type VersionError struct {
+	Version uint8
+}
+
+func (e *VersionError) Error() string {
+	return fmt.Sprintf("Unsupported SST version: %d", e.Version)
+}
+
+func ProcessRaw(sst_data []byte) (front, rear []uint16, markers []float64, meta psst.Meta, err error) {
 	f := bytes.NewReader(sst_data)
-	headers := make([]header, 1)
-	err = binary.Read(f, binary.LittleEndian, &headers)
+	var fileHeader header
+	err = binary.Read(f, binary.LittleEndian, &fileHeader)
 	if err != nil {
 		return
 	}
-	fileHeader := headers[0]
 
-	if string(fileHeader.Magic[:]) == "SST" {
-		meta.Version = fileHeader.Version
-		meta.SampleRate = fileHeader.SampleRate
-		meta.Timestamp = fileHeader.Timestamp
-	} else {
+	if string(fileHeader.Magic[:]) != "SST" {
 		err = &NotSSTError{}
 		return
 	}
 
-	records := make([]record, (len(sst_data)-16 /* sizeof(header) */)/4 /* sizeof(record) */)
-	err = binary.Read(f, binary.LittleEndian, &records)
-	if err != nil {
+	if fileHeader.Version != 4 {
+		err = &VersionError{Version: fileHeader.Version}
 		return
 	}
+
+	meta.Version = fileHeader.Version
+	meta.Timestamp = fileHeader.Timestamp
+	meta.Name = "SST Session"
+
+	var records []record
+	var totalTelemetrySamples int
+
+	for {
+		var ch chunkHeader
+		err = binary.Read(f, binary.LittleEndian, &ch)
+		if err == io.EOF {
+			err = nil
+			break
+		}
+		if err != nil {
+			return
+		}
+
+		switch ch.Type {
+		case ChunkTypeRates:
+			numEntries := int(ch.Length) / 3
+			for i := 0; i < numEntries; i++ {
+				var re rateEntry
+				if err = binary.Read(f, binary.LittleEndian, &re); err != nil {
+					return
+				}
+				if re.Type == ChunkTypeTelemetry {
+					meta.TelemetrySampleRate = re.Rate
+				}
+			}
+		case ChunkTypeTelemetry:
+			numSamples := int(ch.Length) / 4
+			chunkRecords := make([]record, numSamples)
+			if err = binary.Read(f, binary.LittleEndian, &chunkRecords); err != nil {
+				return
+			}
+			records = append(records, chunkRecords...)
+			totalTelemetrySamples += numSamples
+		case ChunkTypeMarker:
+			if meta.TelemetrySampleRate > 0 {
+				markers = append(markers, float64(totalTelemetrySamples)/float64(meta.TelemetrySampleRate))
+			}
+		default:
+			// Skip unknown chunk
+			if _, err = f.Seek(int64(ch.Length), io.SeekCurrent); err != nil {
+				return
+			}
+		}
+	}
+
+	if len(records) == 0 {
+		return
+	}
+
 	var hasFront = records[0].ForkAngle != 0xffff
 	var hasRear = records[0].ShockAngle != 0xffff
 

--- a/test_utils/byb2sst/main.go
+++ b/test_utils/byb2sst/main.go
@@ -264,10 +264,10 @@ func main() {
 		start = time.Now()
 	}
 	meta := psst.Meta{
-		Name:       sessionName,
-		Version:    1,
-		SampleRate: 1000,
-		Timestamp:  start.Unix(),
+		Name:                sessionName,
+		Version:             1,
+		TelemetrySampleRate: 1000,
+		Timestamp:           start.Unix(),
 	}
 
 	fork, shock, err := loadData(opts.BybFile, start.Unix())
@@ -280,7 +280,7 @@ func main() {
 		FrontCalibration: fcal,
 		RearCalibration:  rcal,
 	}
-	pd, err := psst.ProcessRecording(fork, shock, meta, setup)
+	pd, err := psst.ProcessRecording(fork, shock, nil, meta, setup)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Implementation of type-length-value encoding for SST files as explained in https://github.com/sghctoma/sst/issues/39
In addition to the existing travel telemetry, adds a new payload-less entity - Marker as a proof of concept.
Markers don't have a timestamp, but are assumed to have the timestamp of the last travel entry before the Marker.

Also includes changes to the deprecated Go processing and Python dashboard to work with the new format.