### PR TITLE
Initial TLV implementation in firmware

### DIFF
--- a/firmware/src/fw/main.c
+++ b/firmware/src/fw/main.c
@@ -38,6 +38,7 @@
 #include "hardware_config.h"
 
 static volatile enum state state;
+static volatile bool marker_pending = false;
 
 static uint32_t scb_orig;
 static uint32_t clock0_orig;
@@ -167,18 +168,31 @@ struct record databuffer2[BUFFER_SIZE];
 struct record *active_buffer = databuffer1;
 uint16_t count = 0;
 
+static void dump_active_buffer(uint16_t size) {
+    multicore_fifo_push_blocking(DUMP);
+    multicore_fifo_push_blocking(size);
+    multicore_fifo_push_blocking((uintptr_t)active_buffer);
+    active_buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
+}
+
 static bool data_acquisition_cb(repeating_timer_t *rt) {
     if (count == BUFFER_SIZE) {
+        dump_active_buffer(BUFFER_SIZE);
         count = 0;
-        multicore_fifo_push_blocking(DUMP);
-        multicore_fifo_push_blocking((uintptr_t)active_buffer);
-        active_buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
     }
 
     active_buffer[count].fork_angle = fork_sensor.measure(&fork_sensor);
     active_buffer[count].shock_angle = shock_sensor.measure(&shock_sensor);
 
     count += 1;
+
+    if (marker_pending) {
+        dump_active_buffer(count);
+        multicore_fifo_push_blocking(MARKER);
+
+        count = 0;
+        marker_pending = false;
+    }
 
     return state == RECORD; // keep repeating if we are still recording
 }
@@ -283,10 +297,24 @@ static int open_datafile() {
         return fr;
     }
 
-    struct header h = {"SST", 3, SAMPLE_RATE, rtc_timestamp()};
+    struct header h = {"SST", 4, 0, rtc_timestamp()};
     f_write(&recording, &h, sizeof(struct header), NULL);
 
+    struct chunk_header ch = {CHUNK_TYPE_RATES, sizeof(struct rate_entry)};
+    f_write(&recording, &ch, sizeof(struct chunk_header), NULL);
+    struct rate_entry re = {CHUNK_TYPE_TELEMETRY, SAMPLE_RATE};
+    f_write(&recording, &re, sizeof(struct rate_entry), NULL);
+
     return index;
+}
+
+static void write_telemetry_chunk(uint16_t size, struct record *buffer) {
+    struct chunk_header ch;
+    ch.type = CHUNK_TYPE_TELEMETRY;
+    ch.length = size * sizeof(struct record);
+    f_write(&recording, &ch, sizeof(struct chunk_header), NULL);
+    f_write(&recording, buffer, ch.length, NULL);
+    f_sync(&recording);
 }
 
 static void data_storage_core1() {
@@ -297,6 +325,8 @@ static void data_storage_core1() {
     enum command cmd;
     uint16_t size;
     struct record *buffer;
+    struct chunk_header ch;
+
     while (true) {
         cmd = (enum command)multicore_fifo_pop_blocking();
         switch (cmd) {
@@ -307,16 +337,21 @@ static void data_storage_core1() {
                 multicore_fifo_push_blocking((uintptr_t)databuffer2);
                 break;
             case DUMP:
+                size = (uint16_t)multicore_fifo_pop_blocking();
                 buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
                 multicore_fifo_push_blocking((uintptr_t)buffer);
-                f_write(&recording, buffer, sizeof(struct record) * BUFFER_SIZE, NULL);
+                write_telemetry_chunk(size, buffer);
+                break;
+            case MARKER:
+                ch.type = CHUNK_TYPE_MARKER;
+                ch.length = 0;
+                f_write(&recording, &ch, sizeof(struct chunk_header), NULL);
                 f_sync(&recording);
                 break;
             case FINISH:
                 size = (uint16_t)multicore_fifo_pop_blocking();
                 buffer = (struct record *)((uintptr_t)multicore_fifo_pop_blocking());
-                f_write(&recording, buffer, sizeof(struct record) * size, NULL);
-                f_sync(&recording);
+                write_telemetry_chunk(size, buffer);
                 f_close(&recording);
                 break;
         }
@@ -714,6 +749,9 @@ static void on_right_press(void *user_data) {
     switch (state) {
         case IDLE:
             state = SLEEP;
+            break;
+        case RECORD:
+            marker_pending = true;
             break;
         case SERVE_TCP:
             tcpserver_finish(&server);

--- a/firmware/src/fw/sst.h
+++ b/firmware/src/fw/sst.h
@@ -24,10 +24,24 @@ enum state {
 };
 #define STATES_COUNT 13
 
+#define CHUNK_TYPE_RATES 0x00
+#define CHUNK_TYPE_TELEMETRY 0x01
+#define CHUNK_TYPE_MARKER 0x02
+
+struct chunk_header {
+    uint8_t type;
+    uint16_t length;
+} __attribute__((packed));
+
+struct rate_entry {
+    uint8_t type;
+    uint16_t rate;
+} __attribute__((packed));
+
 struct header {
     char magic[3];
     uint8_t version;
-    uint16_t sample_rate;
+    uint32_t padding;
     time_t timestamp;
 };
 
@@ -36,7 +50,7 @@ struct record {
     uint16_t shock_angle;
 };
 
-enum command { OPEN, DUMP, FINISH };
+enum command { OPEN, DUMP, FINISH, MARKER };
 
 #define BUFFER_SIZE 2048
 #define FILENAME_LENGTH                                                                                                \

--- a/firmware/test_utils/inspect_sst_data.py
+++ b/firmware/test_utils/inspect_sst_data.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import argparse
+import struct
+import os
+
+# Chunk type names from firmware/src/fw/sst.h
+CHUNK_TYPES = {
+    0x00: "RATES",
+    0x01: "TRAVEL",
+    0x02: "MARKER",
+    0x03: "IMU",
+    0x04: "IMU_META",
+    0x05: "GPS",
+}
+
+# Record sizes in bytes (from sst.h)
+RECORD_SIZES = {
+    0x00: 3,   # samplerate_record: uint8_t type + uint16_t rate (packed)
+    0x01: 4,   # travel_record: 2 * uint16_t
+    0x02: 0,   # marker: zero-length payload
+    0x03: 12,  # imu_record: 6 * int16_t
+    0x04: 9,   # imu_meta_record: uint8_t + float + float (packed)
+    0x05: 46,  # gps_record: see sst.h for full layout
+}
+
+
+def parse_sst(path):
+    with open(path, "rb") as f:
+        # Header: Magic(3), Version(1), Padding(4), Timestamp(8)
+        header_fmt = "<3sB4xq"
+        header_size = struct.calcsize(header_fmt)
+        data = f.read(header_size)
+        if len(data) != header_size:
+            print("Error reading header")
+            return None
+
+        magic, version, timestamp = struct.unpack(header_fmt, data)
+        if magic != b"SST":
+            print(f"Invalid magic: {magic}")
+            return None
+
+        print(f"SST Version: {version}")
+        print(f"Timestamp: {timestamp}")
+        print()
+
+        # Track chunk counts, record counts, and sample rates
+        chunk_counts = {}
+        record_counts = {}
+        sample_rates = {}
+
+        chunk_header_fmt = "<BH"  # Type(1), Length(2)
+
+        while True:
+            chunk_header_data = f.read(3)
+            if not chunk_header_data:
+                break
+
+            if len(chunk_header_data) < 3:
+                print("Incomplete chunk header")
+                break
+
+            chunk_type, chunk_len = struct.unpack(chunk_header_fmt, chunk_header_data)
+            chunk_body = f.read(chunk_len)
+
+            if len(chunk_body) != chunk_len:
+                print("Incomplete chunk body")
+                break
+
+            # Count this chunk type
+            chunk_counts[chunk_type] = chunk_counts.get(chunk_type, 0) + 1
+
+            # Count records within chunk
+            record_size = RECORD_SIZES.get(chunk_type)
+            if record_size is not None:
+                if record_size == 0:
+                    # Marker chunks count as 1 record each
+                    num_records = 1
+                elif chunk_len > 0:
+                    num_records = chunk_len // record_size
+                else:
+                    num_records = 0
+                record_counts[chunk_type] = record_counts.get(chunk_type, 0) + num_records
+
+            # Parse sample rates from RATES chunk
+            if chunk_type == 0x00:  # RATES
+                num_entries = chunk_len // 3
+                for i in range(num_entries):
+                    rtype, rrate = struct.unpack_from("<BH", chunk_body, i * 3)
+                    type_name = CHUNK_TYPES.get(rtype, f"0x{rtype:02X}")
+                    sample_rates[type_name] = rrate
+
+        # Print chunk summary with record counts
+        print("Chunks found:")
+        for chunk_type, count in sorted(chunk_counts.items()):
+            type_name = CHUNK_TYPES.get(chunk_type, f"0x{chunk_type:02X}")
+            records = record_counts.get(chunk_type, 0)
+            print(f"  {type_name} (0x{chunk_type:02X}): {count} chunks, {records} records")
+
+        # Print sample rates
+        if sample_rates:
+            print()
+            print("Sample rates:")
+            for type_name, rate in sample_rates.items():
+                print(f"  {type_name}: {rate} Hz")
+
+        return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Inspect SST file structure")
+    parser.add_argument("file", help="Path to binary SST file")
+    args = parser.parse_args()
+    if os.path.exists(args.file):
+        parse_sst(args.file)
+    else:
+        print(f"File not found: {args.file}")


### PR DESCRIPTION
Implementation of type-length-value encoding for SST files as explained in https://github.com/sghctoma/sst/issues/39

In addition to the existing travel telemetry, adds a new payload-less entity - Marker as a proof of concept.
Markers don't have a timestamp, but are assumed to have the timestamp of the last travel entry before the Marker.